### PR TITLE
feat: #3 add Navbar Component and Story

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -6,6 +8,13 @@ module.exports = {
     '@storybook/addon-actions',
     '@storybook/addon-interactions',
     '@storybook/addon-controls',
+    {
+      name: 'storybook-addon-next',
+      options: {
+        nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      },
+    },
+    'storybook-addon-styled-component-theme/dist/preset',
   ],
   framework: '@storybook/react',
   core: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,20 @@
+import { addDecorator } from '@storybook/react';
+import { withThemesProvider } from 'storybook-addon-styled-component-theme';
+import { ThemeProvider } from 'styled-components';
+import theme from '../src/constants/theme';
+import GlobalStyle from '../src/styles/globalStyles';
+
+addDecorator(withThemesProvider([theme]), ThemeProvider);
+
+export const decorators = [
+  (Story) => (
+    <>
+      <GlobalStyle />
+      <Story />
+    </>
+  ),
+];
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  compiler: {
+    styledComponents: {
+      ssr: true,
+      displayName: true,
+      pure: true,
+      fileName: true,
+    },
+  },
   webpack(config) {
     const prod = process.env.NODE_ENV === 'production';
     const plugins = [...config.plugins];

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "eslint-plugin-storybook": "^0.6.6",
     "prettier": "^2.7.1",
     "sb": "^6.5.12",
+    "storybook-addon-next": "^1.6.9",
+    "storybook-addon-styled-component-theme": "^2.0.0",
     "typescript": "4.8.4",
     "webpack": "^5.74.0"
   },

--- a/src/components/common/link/link.tsx
+++ b/src/components/common/link/link.tsx
@@ -3,12 +3,20 @@ import NextLink from 'next/link';
 
 interface LinkProps extends NextLinkProps {
   children?: React.ReactNode;
+  width?: string;
 }
 
-const Link = ({ href, children, ...props }: LinkProps) => {
+const Link = ({ href, children, width, ...props }: LinkProps) => {
   return (
     <NextLink href={href}>
-      <a {...props}>{children}</a>
+      <a
+        style={{
+          width,
+        }}
+        {...props}
+      >
+        {children}
+      </a>
     </NextLink>
   );
 };

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -10,7 +10,7 @@ interface LayoutProps {
 const navlinks: NavbarLinks[] = [
   {
     title: '매장',
-    link: 'shops',
+    link: 'market',
     subMenu: [
       {
         title: '스포츠카',

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,14 +1,90 @@
 import Header from './header';
 import * as Styled from './layout.styled';
+import Navbar from './navbar';
+import type { NavbarLinks } from './navbar/navbar';
 
 interface LayoutProps {
   children?: React.ReactNode;
 }
 
+const navlinks: NavbarLinks[] = [
+  {
+    title: '매장',
+    link: 'shops',
+    subMenu: [
+      {
+        title: '스포츠카',
+        link: '스포츠카',
+      },
+      {
+        title: '세단',
+        link: '세단',
+      },
+      {
+        title: 'SUV',
+        link: 'SUV',
+      },
+      {
+        title: '픽업트럭',
+        link: '픽업트럭',
+      },
+      {
+        title: '클래식카&올드카',
+        link: '클래식카&올드카',
+      },
+    ],
+  },
+  {
+    title: '슈마매거진',
+    link: 'magazine',
+  },
+  {
+    title: '커뮤니티',
+    link: 'community',
+    subMenu: [
+      {
+        title: '파파라치',
+        link: '파파라치',
+      },
+      {
+        title: '자료실',
+        link: '자료실',
+      },
+    ],
+  },
+  {
+    title: '제휴업체',
+    link: 'partnership',
+    subMenu: [
+      {
+        title: '자동차매장',
+        link: '자동차매장',
+      },
+      {
+        title: '공업사',
+        link: '공업사',
+      },
+      {
+        title: '디테일링',
+        link: '디테일링',
+      },
+      {
+        title: '도색',
+        link: '도색',
+      },
+      {
+        title: '기타',
+        link: '기타',
+      },
+    ],
+  },
+];
+
 const Layout = ({ children }: LayoutProps) => {
   return (
     <Styled.Container>
       <Header />
+      <Navbar navlinks={navlinks} />
       <Styled.Main>{children}</Styled.Main>
     </Styled.Container>
   );

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -14,23 +14,23 @@ const navlinks: NavbarLinks[] = [
     subMenu: [
       {
         title: '스포츠카',
-        link: '스포츠카',
+        link: 'sports-car',
       },
       {
         title: '세단',
-        link: '세단',
+        link: 'saloon',
       },
       {
         title: 'SUV',
-        link: 'SUV',
+        link: 'suv',
       },
       {
         title: '픽업트럭',
-        link: '픽업트럭',
+        link: 'pickup-truck',
       },
       {
         title: '클래식카&올드카',
-        link: '클래식카&올드카',
+        link: 'classic-car&old-car',
       },
     ],
   },
@@ -44,11 +44,11 @@ const navlinks: NavbarLinks[] = [
     subMenu: [
       {
         title: '파파라치',
-        link: '파파라치',
+        link: 'paparazzo',
       },
       {
         title: '자료실',
-        link: '자료실',
+        link: 'reference-room',
       },
     ],
   },
@@ -58,23 +58,23 @@ const navlinks: NavbarLinks[] = [
     subMenu: [
       {
         title: '자동차매장',
-        link: '자동차매장',
+        link: 'automobile-store',
       },
       {
         title: '공업사',
-        link: '공업사',
+        link: 'industries',
       },
       {
         title: '디테일링',
-        link: '디테일링',
+        link: 'detail-ring',
       },
       {
         title: '도색',
-        link: '도색',
+        link: 'painting',
       },
       {
         title: '기타',
-        link: '기타',
+        link: 'misc',
       },
     ],
   },

--- a/src/components/layout/navbar/index.ts
+++ b/src/components/layout/navbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './navbar';

--- a/src/components/layout/navbar/navbar.stories.tsx
+++ b/src/components/layout/navbar/navbar.stories.tsx
@@ -1,0 +1,35 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Navbar from './navbar';
+
+export default {
+  title: 'Design System/Layout/Navbar',
+  component: Navbar,
+} as ComponentMeta<typeof Navbar>;
+
+const Template: ComponentStory<typeof Navbar> = (args) => <Navbar {...args} />;
+
+export const Default = Template.bind({});
+
+Default.argTypes = {};
+
+Default.args = {
+  navlinks: [
+    {
+      title: '매장',
+      link: 'shops',
+    },
+    {
+      title: '슈마매거진',
+      link: 'magazine',
+    },
+    {
+      title: '커뮤니티',
+      link: 'community',
+    },
+    {
+      title: '제휴업체',
+      link: 'partnership',
+    },
+  ],
+};

--- a/src/components/layout/navbar/navbar.stories.tsx
+++ b/src/components/layout/navbar/navbar.stories.tsx
@@ -18,6 +18,28 @@ Default.args = {
     {
       title: '매장',
       link: 'shops',
+      subMenu: [
+        {
+          title: '스포츠카',
+          link: '스포츠카',
+        },
+        {
+          title: '세단',
+          link: '세단',
+        },
+        {
+          title: 'SUV',
+          link: 'SUV',
+        },
+        {
+          title: '픽업트럭',
+          link: '픽업트럭',
+        },
+        {
+          title: '클래식카&올드카',
+          link: '클래식카&올드카',
+        },
+      ],
     },
     {
       title: '슈마매거진',
@@ -26,10 +48,42 @@ Default.args = {
     {
       title: '커뮤니티',
       link: 'community',
+      subMenu: [
+        {
+          title: '파파라치',
+          link: '파파라치',
+        },
+        {
+          title: '자료실',
+          link: '자료실',
+        },
+      ],
     },
     {
       title: '제휴업체',
       link: 'partnership',
+      subMenu: [
+        {
+          title: '자동차매장',
+          link: '자동차매장',
+        },
+        {
+          title: '공업사',
+          link: '공업사',
+        },
+        {
+          title: '디테일링',
+          link: '디테일링',
+        },
+        {
+          title: '도색',
+          link: '도색',
+        },
+        {
+          title: '기타',
+          link: '기타',
+        },
+      ],
     },
   ],
 };

--- a/src/components/layout/navbar/navbar.stories.tsx
+++ b/src/components/layout/navbar/navbar.stories.tsx
@@ -17,7 +17,7 @@ Default.args = {
   navlinks: [
     {
       title: '매장',
-      link: 'shops',
+      link: 'market',
       subMenu: [
         {
           title: '스포츠카',

--- a/src/components/layout/navbar/navbar.styled.ts
+++ b/src/components/layout/navbar/navbar.styled.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const Container = styled.nav`
+  width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+export { Container };

--- a/src/components/layout/navbar/navbar.styled.ts
+++ b/src/components/layout/navbar/navbar.styled.ts
@@ -8,4 +8,17 @@ const Container = styled.nav`
   justify-content: space-around;
 `;
 
-export { Container };
+const Divider = styled.div`
+  width: 255px;
+  height: 3px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 12px;
+  background-color: ${({ theme }) => theme.color['greyScale-6']};
+  &[data-active='false'] {
+    display: none;
+  }
+`;
+
+export { Container, Divider };

--- a/src/components/layout/navbar/navbar.tsx
+++ b/src/components/layout/navbar/navbar.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx';
+import Typography from 'components/common/typography';
+import { memo } from 'react';
+import css from 'styled-jsx/css';
+
+import * as Styled from './navbar.styled';
+import NavbarItem from './navbarItem';
+
+export interface NavbarLinks {
+  title: string;
+  link: string;
+  subMenu?: undefined | NavbarLinks[];
+}
+
+interface NavbarProps {
+  navlinks: NavbarLinks[];
+}
+
+const NavLink = memo(function NavLink({ title, subMenu }: NavbarLinks) {
+  return (
+    <div className={clsx('navlink')}>
+      <label htmlFor={title} hidden>
+        {title}
+      </label>
+      <button id={title} className={clsx('navlink-button')}>
+        <Typography
+          as="a"
+          fontSize="header-16"
+          fontWeight="bold"
+          lineHeight="120%"
+          color="black"
+        >
+          {title}
+        </Typography>
+      </button>
+      <NavbarItem subMenu={subMenu} />
+      <style jsx>{`
+        .navlink {
+          padding-top: 20px;
+          padding-bottom: 15px;
+          position: relative;
+        }
+        .navlink-button {
+          all: unset;
+          cursor: pointer;
+        }
+      `}</style>
+    </div>
+  );
+});
+
+const Navbar = ({ navlinks }: NavbarProps) => {
+  return (
+    <Styled.Container>
+      {navlinks.map((navlink) => (
+        <NavLink key={navlink.title} {...navlink} />
+      ))}
+    </Styled.Container>
+  );
+};
+
+export default Navbar;

--- a/src/components/layout/navbar/navbar.tsx
+++ b/src/components/layout/navbar/navbar.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Typography from 'components/common/typography';
-import { memo } from 'react';
-import css from 'styled-jsx/css';
+import { useRouter } from 'next/router';
+import { memo, useState } from 'react';
 
 import * as Styled from './navbar.styled';
 import NavbarItem from './navbarItem';
@@ -16,9 +16,15 @@ interface NavbarProps {
   navlinks: NavbarLinks[];
 }
 
-const NavLink = memo(function NavLink({ title, subMenu }: NavbarLinks) {
+const NavLink = memo(function NavLink({ title, subMenu, link }: NavbarLinks) {
+  const [active, setActive] = useState<boolean>(false);
+  const { pathname } = useRouter();
   return (
-    <div className={clsx('navlink')}>
+    <div
+      className={clsx('navlink')}
+      onMouseOver={() => setActive(true)}
+      onMouseOut={() => setActive(false)}
+    >
       <label htmlFor={title} hidden>
         {title}
       </label>
@@ -33,7 +39,8 @@ const NavLink = memo(function NavLink({ title, subMenu }: NavbarLinks) {
           {title}
         </Typography>
       </button>
-      <NavbarItem subMenu={subMenu} />
+      <Styled.Divider data-active={pathname.includes(link)} />
+      <NavbarItem subMenu={subMenu} link={link} active={active} />
       <style jsx>{`
         .navlink {
           padding-top: 20px;

--- a/src/components/layout/navbar/navbarItem.tsx
+++ b/src/components/layout/navbar/navbarItem.tsx
@@ -1,18 +1,30 @@
 import clsx from 'clsx';
 import Link from 'components/common/link';
-import css from 'styled-jsx/css';
+import { useRouter } from 'next/router';
+import { memo } from 'react';
 
 import { NavbarLinks } from './navbar';
 
-const NavbarItem = ({ subMenu }: Pick<NavbarLinks, 'subMenu'>) => {
+const NavbarItem = memo(function NavbarItem({
+  subMenu,
+  active,
+  link,
+}: Pick<NavbarLinks, 'subMenu'> & { active: boolean; link: string }) {
+  const { pathname } = useRouter();
+
   return (
     <>
       {subMenu?.length && (
-        <ul className={clsx('navbarItem')}>
+        <ul data-active={active} className={clsx('navbarItem')}>
           {subMenu.map((s) => (
-            <li key={s.title} className={clsx('navbarItem-li')}>
-              <Link href={s.link}>{s.title}</Link>
-            </li>
+            <Link key={s.title} width="100%" href={'/' + link + '/' + s.link}>
+              <li
+                data-active={pathname.includes(s.link)}
+                className={clsx('navbarItem-li')}
+              >
+                {s.title}
+              </li>
+            </Link>
           ))}
         </ul>
       )}
@@ -21,10 +33,14 @@ const NavbarItem = ({ subMenu }: Pick<NavbarLinks, 'subMenu'>) => {
           box-sizing: border-box;
           position: absolute;
           width: 255px;
+          margin-top: 15px;
           border: 1px solid #eaeaec;
           border-radius: 4px;
           left: 50%;
           transform: translateX(-50%);
+        }
+        .navbarItem[data-active='false'] {
+          display: none;
         }
         .navbarItem-li {
           padding: 11.5px 24px;
@@ -32,16 +48,21 @@ const NavbarItem = ({ subMenu }: Pick<NavbarLinks, 'subMenu'>) => {
           font-weight: 400;
           font-size: 14px;
           line-height: 150%;
+          cursor: pointer;
+        }
+        .navbarItem-li[data-active='true'] {
+          color: #b79f7b;
+          background-color: #f7f7f8;
+          font-weight: 700;
         }
         .navbarItem-li:hover {
           color: #b79f7b;
           background-color: #f7f7f8;
           font-weight: 700;
-          font-size: 14px;
         }
       `}</style>
     </>
   );
-};
+});
 
 export default NavbarItem;

--- a/src/components/layout/navbar/navbarItem.tsx
+++ b/src/components/layout/navbar/navbarItem.tsx
@@ -1,0 +1,47 @@
+import clsx from 'clsx';
+import Link from 'components/common/link';
+import css from 'styled-jsx/css';
+
+import { NavbarLinks } from './navbar';
+
+const NavbarItem = ({ subMenu }: Pick<NavbarLinks, 'subMenu'>) => {
+  return (
+    <>
+      {subMenu?.length && (
+        <ul className={clsx('navbarItem')}>
+          {subMenu.map((s) => (
+            <li key={s.title} className={clsx('navbarItem-li')}>
+              <Link href={s.link}>{s.title}</Link>
+            </li>
+          ))}
+        </ul>
+      )}
+      <style jsx>{`
+        .navbarItem {
+          box-sizing: border-box;
+          position: absolute;
+          width: 255px;
+          border: 1px solid #eaeaec;
+          border-radius: 4px;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+        .navbarItem-li {
+          padding: 11.5px 24px;
+          background-color: #fff;
+          font-weight: 400;
+          font-size: 14px;
+          line-height: 150%;
+        }
+        .navbarItem-li:hover {
+          color: #b79f7b;
+          background-color: #f7f7f8;
+          font-weight: 700;
+          font-size: 14px;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default NavbarItem;

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -21,6 +21,10 @@ const GlobalStyle = createGlobalStyle`
     width: 100%;
     font-family: 'Pretendard';
   }
+
+  a {
+    all: unset;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
# Pull Request

- [x] Feature
- [ ] Fix bug
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

Navbar 컴포넌트와 스토리를 만들어두었습니다.
이후 계획은 Navbar 컴포넌트와 Header 컴포넌트 테스트입니다

<img width="906" alt="스크린샷 2022-10-18 오후 1 45 14" src="https://user-images.githubusercontent.com/66871265/196338299-297bcb5a-e28c-461b-a9eb-d7cd92d434f1.png">

<img width="1429" alt="스크린샷 2022-10-18 오후 1 44 33" src="https://user-images.githubusercontent.com/66871265/196338281-2859a1a8-a5e8-437f-bc52-50893bf19f02.png">


## Describe your changes

- 스토리북의 스타일드컴포넌트 에드온과 next.js 에드온이 추가되었습니다
- 성진님과 얘기했었던 swc의 스타일드컴포넌트 설정을 on 했습니다


## Issue number and link

#1 
#3 
