### PR TITLE
refactor: Wrapper 컴포넌트로 시맨틱 태그 재사용

### DIFF
--- a/src/components/common/card/card.styled.ts
+++ b/src/components/common/card/card.styled.ts
@@ -1,16 +1,16 @@
-import styled from 'styled-components';
+'use client';
 
-const CommunityUserWrapper = styled.div`
+import { css } from 'styled-components';
+
+const communityUserWrapper = css`
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 20px;
 `;
 
-const CommunityTitleWrapper = styled.div`
+const communityTitleWrapper = css`
   margin-top: 10px;
 `;
 
-const CommunityInfoWrapper = styled.div``;
-
-export { CommunityInfoWrapper, CommunityTitleWrapper, CommunityUserWrapper };
+export { communityTitleWrapper, communityUserWrapper };

--- a/src/components/common/card/communityCard.tsx
+++ b/src/components/common/card/communityCard.tsx
@@ -5,7 +5,8 @@ import type { WithBlurredImage } from 'types/magazine';
 
 import Container from '../container';
 import Typography from '../typography';
-import * as Styled from './card.styled';
+import Wrapper from '../wrapper';
+import * as style from './card.styled';
 
 const CommunityCard = ({
   profileSrc,
@@ -27,7 +28,7 @@ const CommunityCard = ({
         placeholder="blur"
         blurDataURL={base64}
       />
-      <Styled.CommunityUserWrapper>
+      <Wrapper css={style.communityUserWrapper}>
         {profileSrc ? (
           <Image
             src={profileSrc}
@@ -49,8 +50,8 @@ const CommunityCard = ({
         >
           {nickName}
         </Typography>
-      </Styled.CommunityUserWrapper>
-      <Styled.CommunityTitleWrapper>
+      </Wrapper>
+      <Wrapper css={style.communityTitleWrapper}>
         <Typography
           as="h2"
           fontSize="header-16"
@@ -65,8 +66,8 @@ const CommunityCard = ({
           fontWeight="bold"
           color="system-1"
         ></Typography>
-      </Styled.CommunityTitleWrapper>
-      <Styled.CommunityInfoWrapper></Styled.CommunityInfoWrapper>
+      </Wrapper>
+      <Wrapper></Wrapper>
     </Container>
   );
 };

--- a/src/components/common/modal/authModal.tsx
+++ b/src/components/common/modal/authModal.tsx
@@ -4,7 +4,8 @@ import { ModalProvider } from 'feature/modalContext';
 import Button from '../button';
 import Container from '../container';
 import Typography from '../typography';
-import { ModalButtonWrapper } from './modal.styled';
+import Wrapper from '../wrapper';
+import * as style from './modal.styled';
 
 const AuthModal = ({ onClose }: ModalContextProps) => {
   return (
@@ -34,7 +35,7 @@ const AuthModal = ({ onClose }: ModalContextProps) => {
         >
           로그인 후 상담 신청이 가능합니다
         </Typography>
-        <ModalButtonWrapper>
+        <Wrapper css={style.modalButtonWrapper}>
           <Button variant="Primary-Line" width="160px">
             <Typography
               as="span"
@@ -57,7 +58,7 @@ const AuthModal = ({ onClose }: ModalContextProps) => {
               로그인
             </Typography>
           </Button>
-        </ModalButtonWrapper>
+        </Wrapper>
       </Container>
     </ModalProvider>
   );

--- a/src/components/common/modal/counselingModal.tsx
+++ b/src/components/common/modal/counselingModal.tsx
@@ -4,7 +4,8 @@ import { User } from 'types/base';
 import Button from '../button';
 import Container from '../container';
 import Typography from '../typography';
-import { ModalButtonWrapper, ModalCallWrapper } from './modal.styled';
+import Wrapper from '../wrapper';
+import * as style from './modal.styled';
 
 interface CounselingModalProps extends ModalContextProps {
   user: User;
@@ -25,7 +26,7 @@ const CounselingModal = ({ user, onClose }: CounselingModalProps) => {
       >
         담당자에게 연락처가 전달됩니다
       </Typography>
-      <ModalCallWrapper>
+      <Wrapper css={style.modalCallWrapper}>
         <Typography
           as="h4"
           fontSize="header-20"
@@ -35,7 +36,7 @@ const CounselingModal = ({ user, onClose }: CounselingModalProps) => {
         >
           {user.call}
         </Typography>
-      </ModalCallWrapper>
+      </Wrapper>
       <Typography
         as="p"
         fontSize="body-16"
@@ -48,7 +49,7 @@ const CounselingModal = ({ user, onClose }: CounselingModalProps) => {
       >
         담당자가 확인 후 연락드리겠습니다
       </Typography>
-      <ModalButtonWrapper>
+      <Wrapper css={style.modalButtonWrapper}>
         <Button variant="Primary-Line" width="160px" onClick={onClose}>
           <Typography
             as="span"
@@ -71,7 +72,7 @@ const CounselingModal = ({ user, onClose }: CounselingModalProps) => {
             신청하기
           </Typography>
         </Button>
-      </ModalButtonWrapper>
+      </Wrapper>
     </Container>
   );
 };

--- a/src/components/common/modal/modal.styled.ts
+++ b/src/components/common/modal/modal.styled.ts
@@ -1,13 +1,15 @@
-import styled from 'styled-components';
+'use client';
 
-const ModalButtonWrapper = styled.div`
+import { css } from 'styled-components';
+
+const modalButtonWrapper = css`
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
 `;
 
-const ModalCallWrapper = styled.div`
+const modalCallWrapper = css`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,4 +19,4 @@ const ModalCallWrapper = styled.div`
   border-radius: 4px;
 `;
 
-export { ModalButtonWrapper, ModalCallWrapper };
+export { modalButtonWrapper, modalCallWrapper };

--- a/src/components/common/posting/posting.styled.ts
+++ b/src/components/common/posting/posting.styled.ts
@@ -1,36 +1,28 @@
-import styled from 'styled-components';
+import { css } from 'styled-components';
 
-const PostingHeadTop = styled.div``;
-
-const PostingHeadBottom = styled.div`
+const bottom = css`
   display: flex;
   align-items: center;
   justify-content: space-between;
 `;
 
-const PostingHeadBottomLeft = styled.div`
+const left = css`
   display: flex;
   align-items: center;
   gap: 10px;
   margin-bottom: 20px;
 `;
 
-const PostingHeadBottomRight = styled.div`
+const right = css`
   display: flex;
   align-items: center;
   gap: 12px;
 `;
 
-const PostingHeadBottomRightWrapper = styled.div`
+const wrapper = css`
   display: flex;
   align-items: center;
   gap: 4px;
 `;
 
-export {
-  PostingHeadBottom,
-  PostingHeadBottomLeft,
-  PostingHeadBottomRight,
-  PostingHeadBottomRightWrapper,
-  PostingHeadTop,
-};
+export { bottom, left, right, wrapper };

--- a/src/components/common/posting/postingHead.tsx
+++ b/src/components/common/posting/postingHead.tsx
@@ -4,13 +4,8 @@ import ChatIcon from '../../../assets/svg/chat.svg';
 import EyeIcon from '../../../assets/svg/remove-red-eye.svg';
 import Container from '../container';
 import Typography from '../typography';
-import {
-  PostingHeadBottom,
-  PostingHeadBottomLeft,
-  PostingHeadBottomRight,
-  PostingHeadBottomRightWrapper,
-  PostingHeadTop,
-} from './posting.styled';
+import Wrapper from '../wrapper';
+import * as style from './posting.styled';
 
 const PostingHead = () => {
   return (
@@ -21,7 +16,7 @@ const PostingHead = () => {
       borderBottom="1px solid #EAEAEC"
       boxSizing="border-box"
     >
-      <PostingHeadTop>
+      <Wrapper.Top>
         <Typography
           as="h2"
           fontSize="header-24"
@@ -31,9 +26,9 @@ const PostingHead = () => {
         >
           제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄제목총100글자두줄
         </Typography>
-      </PostingHeadTop>
-      <PostingHeadBottom>
-        <PostingHeadBottomLeft>
+      </Wrapper.Top>
+      <Wrapper.Bottom css={style.bottom}>
+        <Wrapper.Left css={style.left}>
           <Avvvatars value="금종선" size={40} />
           <Typography
             as="span"
@@ -53,9 +48,9 @@ const PostingHead = () => {
           >
             2022. 9. 14 16:24
           </Typography>
-        </PostingHeadBottomLeft>
-        <PostingHeadBottomRight>
-          <PostingHeadBottomRightWrapper>
+        </Wrapper.Left>
+        <Wrapper.Right css={style.right}>
+          <Wrapper css={style.wrapper}>
             <ChatIcon />
             <Typography
               as="span"
@@ -66,8 +61,8 @@ const PostingHead = () => {
             >
               15554
             </Typography>
-          </PostingHeadBottomRightWrapper>
-          <PostingHeadBottomRightWrapper>
+          </Wrapper>
+          <Wrapper css={style.wrapper}>
             <EyeIcon />
             <Typography
               as="span"
@@ -78,9 +73,9 @@ const PostingHead = () => {
             >
               12
             </Typography>
-          </PostingHeadBottomRightWrapper>
-        </PostingHeadBottomRight>
-      </PostingHeadBottom>
+          </Wrapper>
+        </Wrapper.Right>
+      </Wrapper.Bottom>
     </Container>
   );
 };

--- a/src/components/common/wrapper/index.ts
+++ b/src/components/common/wrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from './wrapper';

--- a/src/components/common/wrapper/wrapper.styled.ts
+++ b/src/components/common/wrapper/wrapper.styled.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import type {
+  DefaultTheme,
+  FlattenInterpolation,
+  FlattenSimpleInterpolation,
+  ThemeProps,
+} from 'styled-components';
+import styled from 'styled-components';
+
+const Container = styled.div<{
+  css:
+    | FlattenSimpleInterpolation
+    | FlattenInterpolation<ThemeProps<DefaultTheme>>
+    | undefined;
+}>`
+  ${({ css }) => css}
+`;
+
+export { Container };

--- a/src/components/common/wrapper/wrapper.tsx
+++ b/src/components/common/wrapper/wrapper.tsx
@@ -1,0 +1,63 @@
+import type { PropsWithChildren } from 'react';
+import type {
+  DefaultTheme,
+  FlattenInterpolation,
+  FlattenSimpleInterpolation,
+  ThemeProps,
+} from 'styled-components';
+
+import { Container } from './wrapper.styled';
+
+interface WrapperProps {
+  css?:
+    | FlattenSimpleInterpolation
+    | FlattenInterpolation<ThemeProps<DefaultTheme>>;
+  className?: string;
+}
+
+const Wrapper = (props: PropsWithChildren<WrapperProps>) => {
+  const { css, children, className = 'wrapper' } = props;
+  return (
+    <Container css={css} className={className}>
+      {children}
+    </Container>
+  );
+};
+
+Wrapper.Top = function Top(props: PropsWithChildren<WrapperProps>) {
+  const { css, children, className = 'top' } = props;
+  return (
+    <Container css={css} className={className}>
+      {children}
+    </Container>
+  );
+};
+
+Wrapper.Bottom = function Bottom(props: PropsWithChildren<WrapperProps>) {
+  const { css, children, className = 'bottom' } = props;
+  return (
+    <Container css={css} className={className}>
+      {children}
+    </Container>
+  );
+};
+
+Wrapper.Left = function Left(props: PropsWithChildren<WrapperProps>) {
+  const { css, children, className = 'left' } = props;
+  return (
+    <Container css={css} className={className}>
+      {children}
+    </Container>
+  );
+};
+
+Wrapper.Right = function Right(props: PropsWithChildren<WrapperProps>) {
+  const { css, children, className = 'right' } = props;
+  return (
+    <Container css={css} className={className}>
+      {children}
+    </Container>
+  );
+};
+
+export default Wrapper;


### PR DESCRIPTION
# Pull Request

- [x] Feature
- [ ] Fix bug
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

![스크린샷 2022-12-02 오후 5 34 31](https://user-images.githubusercontent.com/66871265/205250577-756b5834-3935-4f60-945f-1460619c185c.png)

![스크린샷 2022-12-02 오후 5 34 42](https://user-images.githubusercontent.com/66871265/205250612-ce53d6e3-be4a-4318-8498-cf3d62098bce.png)

Wrapper 컴포넌트를 사용한 컴포넌트 래핑 방법입니다! 
styled-components의 css api를 활용하여 스타일을 작성하면됩니다!
## Issue number and link
